### PR TITLE
Fix session mode assignment

### DIFF
--- a/src/main/java/com/xiaozhi/communication/common/MessageHandler.java
+++ b/src/main/java/com/xiaozhi/communication/common/MessageHandler.java
@@ -337,7 +337,7 @@ public class MessageHandler {
         String mode = jsonNode.path("mode").asText();
 
         logger.info("收到listen消息 - SessionId: {}, State: {}, Mode: {}", sessionId, state, mode);
-        sessionManager.setMode(mode);
+        sessionManager.setMode(sessionId, mode);
 
         // 根据state处理不同的监听状态
         switch (state) {

--- a/src/main/java/com/xiaozhi/communication/common/SessionManager.java
+++ b/src/main/java/com/xiaozhi/communication/common/SessionManager.java
@@ -423,12 +423,13 @@ public class SessionManager {
     }
 
     /**
-     * 设备状态
-     * 
-     * @param mode  设备状态 auto/realTime
+     * 设置会话的工作模式
+     *
+     * @param sessionId 会话ID
+     * @param mode      设备状态 auto/realTime
      */
-    public void setMode(String mode) {
-        ChatSession chatSession = sessions.get(mode);
+    public void setMode(String sessionId, String mode) {
+        ChatSession chatSession = sessions.get(sessionId);
         if (chatSession != null) {
             chatSession.setMode(mode);
         }


### PR DESCRIPTION
## Summary
- correct `SessionManager#setMode` to use sessionId
- update `MessageHandler` to pass sessionId when setting mode

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845967d7a988331b197c8e3a539dccf